### PR TITLE
Update check_chrony

### DIFF
--- a/check_chrony
+++ b/check_chrony
@@ -21,7 +21,7 @@ use strict;
 use warnings;
 use utf8;
 use Getopt::Std;
-no warnings 'experimental::smartmatch';
+#no warnings 'experimental::smartmatch';
 
 #
 # Variables


### PR DESCRIPTION
in perl 5.16.3 would result in unknown warnings errors
Command out no warnings would allow the script to run
![image](https://user-images.githubusercontent.com/24373139/90465983-2a7b3f00-e143-11ea-96cb-58ced4e6747e.png)

